### PR TITLE
applied auto layout to main storyboard

### DIFF
--- a/map-app/map-app/Base.lproj/Main.storyboard
+++ b/map-app/map-app/Base.lproj/Main.storyboard
@@ -9,7 +9,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Home View Controller-->
+        <!--MAP APP-->
         <scene sceneID="tne-QT-ifu">
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="HomeViewController" customModule="map_app" customModuleProvider="target" sceneMemberID="viewController">
@@ -17,25 +17,20 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="FUTURE TITLE" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qxj-Wj-u9j">
-                                <rect key="frame" x="16" y="88" width="343" height="50"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="cFb-v9-MFP">
-                                <rect key="frame" x="16" y="159" width="343" height="587"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="cFb-v9-MFP">
+                                <rect key="frame" x="16" y="132.66666666666669" width="343" height="619.66666666666652"/>
+                                <color key="backgroundColor" red="0.39501391882183912" green="0.39501391882183912" blue="0.39501391882183912" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="separatorColor" red="0.4755185884" green="0.4755185884" blue="0.4755185884" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="LocationCell" id="8RW-yF-Icg">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="LocationCell" id="8RW-yF-Icg">
                                         <rect key="frame" x="0.0" y="28" width="343" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8RW-yF-Icg" id="cyQ-QE-s0w">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="43.666666666666664"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="310" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <color key="backgroundColor" red="0.396078431372549" green="0.396078431372549" blue="0.396078431372549" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </tableViewCellContentView>
+                                        <color key="backgroundColor" red="0.396078431372549" green="0.396078431372549" blue="0.396078431372549" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <connections>
                                             <segue destination="xSM-Xm-8WU" kind="show" id="Aff-oT-kRe"/>
                                         </connections>
@@ -46,11 +41,26 @@
                                     <outlet property="delegate" destination="BYZ-38-t0r" id="DxF-hu-sTG"/>
                                 </connections>
                             </tableView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="click on a park near you to explore!" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qxj-Wj-u9j">
+                                <rect key="frame" x="32" y="85" width="310.33333333333331" height="59"/>
+                                <fontDescription key="fontDescription" type="system" weight="thin" pointSize="22"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="qxj-Wj-u9j" secondAttribute="trailing" constant="32.666666666666686" id="2N3-Sm-7w7"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="cFb-v9-MFP" secondAttribute="trailing" constant="16" id="H74-Jn-j0S"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="cFb-v9-MFP" secondAttribute="bottom" constant="25.670000000000002" id="YDx-tl-EOZ"/>
+                            <constraint firstItem="qxj-Wj-u9j" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="32" id="mGD-xn-L2Z"/>
+                            <constraint firstItem="cFb-v9-MFP" firstAttribute="top" secondItem="qxj-Wj-u9j" secondAttribute="bottom" constant="8.3333333333333712" id="ox1-kJ-pLr"/>
+                            <constraint firstItem="qxj-Wj-u9j" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="10" id="pCD-xJ-L4J"/>
+                            <constraint firstItem="cFb-v9-MFP" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="usQ-h5-yZg"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
-                    <navigationItem key="navigationItem" id="YdD-zp-h25"/>
+                    <navigationItem key="navigationItem" title="MAP APP" largeTitleDisplayMode="always" id="YdD-zp-h25"/>
                     <connections>
                         <outlet property="titleLabel" destination="qxj-Wj-u9j" id="2Zk-BS-jJx"/>
                     </connections>


### PR DESCRIPTION
## What you did :question:
Applied auto-layout to main storyboard, adjusted colors to a darker-mode.

## How you did it :white_check_mark:
Used auto-layout constraints to create a consistent layout across device sizes. Changed color scheme to a darker-grey scheme.
**NOTE**: I still want to change the navbar to match the background's grey, and also change the cell text to white.


## How to test it :microscope:
You can pull down the branch `storyboard-auto-layout` branch and run the app on an iphone 6S or somethin'!


## Screenshots (if applicable) :camera:
<img width="381" alt="screen shot 2018-10-03 at 10 54 03 am" src="https://user-images.githubusercontent.com/37513899/46418893-a9eff880-c6fa-11e8-9dfe-5bf1675ddb0f.png">
