### PR TITLE
changed selected cell color from white to greenish

### DIFF
--- a/map-app/map-app/AppDelegate.swift
+++ b/map-app/map-app/AppDelegate.swift
@@ -16,6 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        customizeAppearance()
         return true
     }
 
@@ -39,6 +40,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+    
+    // MARK: - Helper Methods
+    
+    func customizeAppearance() {
+        
+        window!.tintColor = UIColor(red: 64/255, green: 167/255, blue: 152/255, alpha: 1)
     }
 
 

--- a/map-app/map-app/AppDelegate.swift
+++ b/map-app/map-app/AppDelegate.swift
@@ -16,7 +16,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        customizeAppearance()
         return true
     }
 
@@ -41,14 +40,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
-    
-    // MARK: - Helper Methods
-    
-    func customizeAppearance() {
-        
-        window!.tintColor = UIColor(red: 64/255, green: 167/255, blue: 152/255, alpha: 1)
-    }
-
-
 }
 

--- a/map-app/map-app/HomeViewController.swift
+++ b/map-app/map-app/HomeViewController.swift
@@ -73,6 +73,12 @@ extension HomeViewController: UITableViewDataSource{
         cell.textLabel?.text = location.name
         cell.textLabel?.textColor = UIColor.white
         cell.textLabel?.font = UIFont.systemFont(ofSize: 20)
+        
+        /// sets background color of cell when cell is selected
+        let backgroundView = UIView()
+        let selectedCellColor = UIColor(red: 64/255, green: 167/255, blue: 152/255, alpha: 1)
+        backgroundView.backgroundColor = selectedCellColor
+        cell.selectedBackgroundView = backgroundView
         return cell
     }
     


### PR DESCRIPTION
## What you did :question:
I changed the selected cell color from a background color of white to a greenish (that matches our logo). Previously, when you clicked a cell it flashed white, making it hard to read the cell for a second (as the font is white). This makes for better readability.

## How you did it :white_check_mark:
I added a few lines of code to the `cellForRowAt` method in `HomeViewController` (see screenshot)


## How to test it :microscope:
You can pull down the branch `selected-cell-color` and run the app. Click on a cell to see !



## Screenshots (if applicable) :camera:
<img width="985" alt="screen shot 2018-10-04 at 3 44 34 pm" src="https://user-images.githubusercontent.com/37513899/46498789-6970a780-c7ec-11e8-9444-b1cc3b07dcdc.png">
